### PR TITLE
BE-25: Implement the user relationship model & friend management API endpoints

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -10,6 +10,7 @@ import dotenv from "dotenv";
 
 import { authMiddleware } from "./utils/authMiddleware";
 import userRouter from "./routes/user";
+import friendRouter from "./routes/friend";
 import AppError from "./utils/appError";
 import globalErrorHandler from "./controllers/error";
 
@@ -44,6 +45,8 @@ app.use(cors());
 
 // Set default route
 app.use("/api/v1/users", userRouter);
+app.use("/api/v1/", authMiddleware, friendRouter);
+
 
 // Handle when go to undefined route
 app.all("*", (req: Request, res: Response, next: NextFunction) => {

--- a/api/src/controllers/friend.ts
+++ b/api/src/controllers/friend.ts
@@ -1,21 +1,31 @@
 import express from "express";
 import graphQLClient from "../utils/graphql";
 import { GET_RELATIONSHIP_TYPE } from "../graphql/queries";
-import { CREATE_RELATIONSHIP, UPDATE_RELATIONSHIP, DELETE_RELATIONSHIP } from "../graphql/mutations";
+import {
+  CREATE_RELATIONSHIP,
+  UPDATE_RELATIONSHIP,
+  DELETE_RELATIONSHIP,
+} from "../graphql/mutations";
 
-const getRelationshipType = async (user_first_id: string, user_second_id: string) => {
+const getRelationshipType = async (
+  user_first_id: string,
+  user_second_id: string
+) => {
   if (user_first_id > user_second_id) {
     const temp = user_first_id;
     user_first_id = user_second_id;
     user_second_id = temp;
   }
-  const { getRelationshipType: response } = await graphQLClient().request(GET_RELATIONSHIP_TYPE, {
-    user_first_id: user_first_id,
-    user_second_id: user_second_id,
-  });
+  const { getRelationshipType: response } = await graphQLClient().request(
+    GET_RELATIONSHIP_TYPE,
+    {
+      user_first_id: user_first_id,
+      user_second_id: user_second_id,
+    }
+  );
 
   return response;
-}
+};
 
 /* Friend Management */
 
@@ -43,7 +53,10 @@ export const addFriend = async (
       user_second_id = current_user;
     }
 
-    const relationshipType = await getRelationshipType(user_first_id, user_second_id)
+    const relationshipType = await getRelationshipType(
+      user_first_id,
+      user_second_id
+    )
       .then((res) => {
         return res;
       })
@@ -74,7 +87,6 @@ export const addFriend = async (
     res.status(200).json({
       message: "Friend request sent.",
     });
-
   } catch (error) {
     return res.status(500).json({
       message: error.message,
@@ -120,13 +132,19 @@ export const acceptFriend = async (
       });
     }
 
-    if (user_first_id == current_user && relationshipType == "PENDING_SECOND_FIRST") {
+    if (
+      user_first_id == current_user &&
+      relationshipType == "PENDING_SECOND_FIRST"
+    ) {
       const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
         user_first_id: current_user,
         user_second_id: friend,
         type: "FRIEND",
       });
-    } else if (user_first_id == friend && relationshipType == "PENDING_FIRST_SECOND") {
+    } else if (
+      user_first_id == friend &&
+      relationshipType == "PENDING_FIRST_SECOND"
+    ) {
       const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
         user_first_id: friend,
         user_second_id: current_user,
@@ -141,7 +159,6 @@ export const acceptFriend = async (
     return res.status(200).json({
       message: "Friend request accepted.",
     });
-
   } catch (error) {
     return res.status(500).json({
       message: error.message,
@@ -184,7 +201,10 @@ export const cancelFriendRequest = async (
         user_first_id: current_user,
         user_second_id: friend,
       });
-    } else if (current_user > friend && relationshipType == "PENDING_SECOND_FIRST") {
+    } else if (
+      current_user > friend &&
+      relationshipType == "PENDING_SECOND_FIRST"
+    ) {
       const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
         user_first_id: friend,
         user_second_id: current_user,
@@ -198,7 +218,6 @@ export const cancelFriendRequest = async (
     return res.status(200).json({
       message: "Friend request cancelled.",
     });
-
   } catch (error) {
     return res.status(500).json({
       message: error.message,
@@ -241,7 +260,10 @@ export const cancelReceivedFriendRequest = async (
         user_first_id: friend,
         user_second_id: current_user,
       });
-    } else if (current_user < friend && relationshipType == "PENDING_SECOND_FIRST") {
+    } else if (
+      current_user < friend &&
+      relationshipType == "PENDING_SECOND_FIRST"
+    ) {
       const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
         user_first_id: current_user,
         user_second_id: friend,
@@ -255,7 +277,6 @@ export const cancelReceivedFriendRequest = async (
     return res.status(200).json({
       message: "Received friend request cancelled.",
     });
-
   } catch (error) {
     return res.status(500).json({
       message: error.message,
@@ -307,7 +328,6 @@ export const removeFriend = async (
     return res.status(200).json({
       message: "Friend removed.",
     });
-
   } catch (error) {
     return res.status(500).json({
       message: error.message,
@@ -334,21 +354,22 @@ export const getRelationshipTypeApi = async (
       user_second_id = current_user;
     }
 
-    const { getRelationshipType: response } = await graphQLClient().request(GET_RELATIONSHIP_TYPE, {
-      user_first_id: current_user,
-      user_second_id: friend,
-    });
+    const { getRelationshipType: response } = await graphQLClient().request(
+      GET_RELATIONSHIP_TYPE,
+      {
+        user_first_id: user_first_id,
+        user_second_id: user_second_id,
+      }
+    );
 
     if (!response) {
-        return res.status(200).json({"type": "NOT-FRIEND"});
+      return res.status(200).json({ type: "NOT-FRIEND" });
     }
 
-    return res.status(200).json({"type": response});
-
+    return res.status(200).json({ type: response });
   } catch (error) {
     return res.status(500).json({
       message: error.message,
     });
   }
 };
-

--- a/api/src/controllers/friend.ts
+++ b/api/src/controllers/friend.ts
@@ -1,0 +1,354 @@
+import express from "express";
+import graphQLClient from "../utils/graphql";
+import { GET_RELATIONSHIP_TYPE } from "../graphql/queries";
+import { CREATE_RELATIONSHIP, UPDATE_RELATIONSHIP, DELETE_RELATIONSHIP } from "../graphql/mutations";
+
+const getRelationshipType = async (user_first_id: string, user_second_id: string) => {
+  if (user_first_id > user_second_id) {
+    const temp = user_first_id;
+    user_first_id = user_second_id;
+    user_second_id = temp;
+  }
+  const { getRelationshipType: response } = await graphQLClient().request(GET_RELATIONSHIP_TYPE, {
+    user_first_id: user_first_id,
+    user_second_id: user_second_id,
+  });
+
+  return response;
+}
+
+/* Friend Management */
+
+// Add user with `id` as friend (Send friend request).
+export const addFriend = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot add yourself as a friend.",
+      });
+    }
+
+    let user_first_id = current_user;
+    let user_second_id = friend;
+
+    if (current_user > friend) {
+      user_first_id = friend;
+      user_second_id = current_user;
+    }
+
+    const relationshipType = await getRelationshipType(user_first_id, user_second_id)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (relationshipType) {
+      return res.status(400).json({
+        message: "You cannot add this user as a friend.",
+      });
+    }
+
+    if (user_first_id == current_user) {
+      const response = await graphQLClient().request(CREATE_RELATIONSHIP, {
+        user_first_id: current_user,
+        user_second_id: friend,
+        type: "PENDING_FIRST_SECOND",
+      });
+    } else {
+      const response = await graphQLClient().request(CREATE_RELATIONSHIP, {
+        user_first_id: friend,
+        user_second_id: current_user,
+        type: "PENDING_SECOND_FIRST",
+      });
+    }
+
+    res.status(200).json({
+      message: "Friend request sent.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// Accept friend request from user with `id`.
+export const acceptFriend = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot accept yourself as a friend.",
+      });
+    }
+
+    let user_first_id = current_user;
+    let user_second_id = friend;
+
+    if (current_user > friend) {
+      user_first_id = friend;
+      user_second_id = current_user;
+    }
+
+    const relationshipType = await getRelationshipType(current_user, friend)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (!relationshipType) {
+      return res.status(400).json({
+        message: "You cannot accept this user as a friend.",
+      });
+    }
+
+    if (user_first_id == current_user && relationshipType == "PENDING_SECOND_FIRST") {
+      const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
+        user_first_id: current_user,
+        user_second_id: friend,
+        type: "FRIEND",
+      });
+    } else if (user_first_id == friend && relationshipType == "PENDING_FIRST_SECOND") {
+      const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
+        user_first_id: friend,
+        user_second_id: current_user,
+        type: "FRIEND",
+      });
+    } else {
+      return res.status(400).json({
+        message: "You cannot accept this user as a friend.",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Friend request accepted.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// Cancel sent friend request to user with `id`.
+export const cancelFriendRequest = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot cancel friend request to yourself.",
+      });
+    }
+
+    const relationshipType = await getRelationshipType(current_user, friend)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (!relationshipType) {
+      return res.status(400).json({
+        message: "You cannot cancel friend request to this user.",
+      });
+    }
+
+    if (current_user < friend && relationshipType == "PENDING_FIRST_SECOND") {
+      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+        user_first_id: current_user,
+        user_second_id: friend,
+      });
+    } else if (current_user > friend && relationshipType == "PENDING_SECOND_FIRST") {
+      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+        user_first_id: friend,
+        user_second_id: current_user,
+      });
+    } else {
+      return res.status(400).json({
+        message: "You cannot cancel friend request to this user.",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Friend request cancelled.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// Cancel received friend request from user with `id`.
+export const cancelReceivedFriendRequest = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot cancel received friend request from yourself.",
+      });
+    }
+
+    const relationshipType = await getRelationshipType(current_user, friend)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (!relationshipType) {
+      return res.status(400).json({
+        message: "You cannot cancel received friend request from this user.",
+      });
+    }
+
+    if (current_user > friend && relationshipType == "PENDING_FIRST_SECOND") {
+      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+        user_first_id: friend,
+        user_second_id: current_user,
+      });
+    } else if (current_user < friend && relationshipType == "PENDING_SECOND_FIRST") {
+      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+        user_first_id: current_user,
+        user_second_id: friend,
+      });
+    } else {
+      return res.status(400).json({
+        message: "You cannot cancel received friend request from this user.",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Received friend request cancelled.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// remove friend with `id`
+export const removeFriend = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot remove yourself as a friend.",
+      });
+    }
+
+    const relationshipType = await getRelationshipType(current_user, friend)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (!relationshipType) {
+      return res.status(400).json({
+        message: "You cannot remove this user as a friend.",
+      });
+    }
+
+    if (relationshipType == "FRIEND") {
+      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+        user_first_id: current_user,
+        user_second_id: friend,
+      });
+    } else {
+      return res.status(400).json({
+        message: "You cannot remove this user as a friend.",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Friend removed.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+/* Listing and Queries */
+
+export const getRelationshipTypeApi = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    let user_first_id = current_user;
+    let user_second_id = friend;
+
+    if (current_user > friend) {
+      user_first_id = friend;
+      user_second_id = current_user;
+    }
+
+    const { getRelationshipType: response } = await graphQLClient().request(GET_RELATIONSHIP_TYPE, {
+      user_first_id: current_user,
+      user_second_id: friend,
+    });
+
+    if (!response) {
+        return res.status(200).json({"type": "NOT-FRIEND"});
+    }
+
+    return res.status(200).json({"type": response});
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+

--- a/api/src/graphql/mutations.ts
+++ b/api/src/graphql/mutations.ts
@@ -24,3 +24,45 @@ export const UPDATE_REFRESH_TOKEN = gql`
     }
   }
 `;
+
+export const CREATE_RELATIONSHIP = gql`
+  mutation createRelationship($user_first_id: ID!, $user_second_id: ID!, $type: RelationshipType!) {
+    createRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id, type: $type) {
+      _id {
+        user_first_id
+        user_second_id
+      }
+      type
+      created_at
+      last_modified
+    }
+  }
+`;
+
+export const UPDATE_RELATIONSHIP = gql`
+  mutation updateRelationship($user_first_id: ID!, $user_second_id: ID!, $type: RelationshipType!) {
+    updateRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id, type: $type) {
+      _id {
+        user_first_id
+        user_second_id
+      }
+      type
+      created_at
+      last_modified
+    }
+  }
+`;
+
+export const DELETE_RELATIONSHIP = gql`
+  mutation deleteRelationship($user_first_id: ID!, $user_second_id: ID!) {
+    deleteRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id) {
+      _id {
+        user_first_id
+        user_second_id
+      }
+      type
+      created_at
+      last_modified
+    }
+  }
+`;

--- a/api/src/graphql/queries.ts
+++ b/api/src/graphql/queries.ts
@@ -46,3 +46,9 @@ export const LOGIN_USER = gql`
     }
   }
 `;
+
+export const GET_RELATIONSHIP_TYPE = gql`
+  query getRelationshipType($user_first_id: ID!, $user_second_id: ID!) {
+    getRelationshipType(user_first_id: $user_first_id, user_second_id: $user_second_id)
+  }
+`;

--- a/api/src/routes/friend.ts
+++ b/api/src/routes/friend.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction, Router } from "express";
+import {addFriend, acceptFriend, cancelFriendRequest, cancelReceivedFriendRequest, removeFriend, getRelationshipTypeApi } from "../controllers/friend";
+import { authMiddleware } from "../utils/authMiddleware";
+
+
+const friendRouter = Router();
+
+/* Friend Management */
+// add user with `id` as friend (Send friend request).
+friendRouter.post('/friends/:id', authMiddleware, addFriend);
+// accept friend request from user with `id`
+friendRouter.post('/friends/accept/:id', authMiddleware, acceptFriend);
+// cancel friend request to user with `id`
+friendRouter.delete('/friends/cancel/sent/:id', authMiddleware, cancelFriendRequest);
+// cancel received friend request from user with `id`
+friendRouter.delete('/friends/cancel/received/:id', authMiddleware, cancelReceivedFriendRequest);
+// remove user with `id` from friends
+friendRouter.delete('/friends/:id', authMiddleware, removeFriend);
+
+/* Listing and Queries */
+friendRouter.get("/relationship/:id", authMiddleware, getRelationshipTypeApi);
+
+
+export default friendRouter;

--- a/api/src/utils/authMiddleware.ts
+++ b/api/src/utils/authMiddleware.ts
@@ -61,8 +61,11 @@ export const authMiddleware = async (
     }
 
     // Save user data to res.locals
-    res.locals.uid = user.id;
-    res.locals.token = token;
+
+    // req.
+    req.params.uid = user.id;
+    // res.locals.uid = user.id;
+    // res.locals.token = token;
     next();
   } catch (error) {
     next(error);

--- a/apollo/package-lock.json
+++ b/apollo/package-lock.json
@@ -21,6 +21,7 @@
         "express-rate-limit": "^7.3.1",
         "graphql": "^16.9.0",
         "graphql-resolvers": "^0.4.2",
+        "graphql-tools": "^9.0.1",
         "helmet": "^7.1.0",
         "mongoose": "^8.4.3",
         "morgan": "^1.10.0",
@@ -34,6 +35,86 @@
         "nodemon": "^3.1.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.2"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.11.tgz",
+      "integrity": "sha512-H7e9m7cRcFO93tokwzqrsbnfKorkpV24xU30hFH5u2g6B+c1DMo/ouyF/YrBPdrTzqxQCjTUmds/FLmJ7626GA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "0.0.6",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@apollo/client/node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@apollo/client/node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -685,6 +766,32 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@wry/equality": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
@@ -699,6 +806,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1217,6 +1337,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-inspect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
@@ -1337,6 +1469,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ee-first": {
@@ -1634,6 +1775,86 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/graphql-tools": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-9.0.1.tgz",
+      "integrity": "sha512-iiIwmaAdsrm23HgnJtpATV9ndsjp/zyfmAJEM8jwckUDxr32HlsD1h3arbs1ck98Gp20kudZkVg+F7s9YpdnWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/schema": "^10.0.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "@apollo/client": "~3.2.5 || ~3.3.0 || ~3.4.0 || ~3.5.0 || ~3.6.0 || ~3.7.0 || ~3.8.0 || ~3.9.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/merge": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
+      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/schema": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
+      "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.0.3",
+        "@graphql-tools/utils": "^10.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/@graphql-tools/utils": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.3.1.tgz",
+      "integrity": "sha512-Yhk1F0MNk4/ctgl3d0DKq++ZPovvZuh1ixWuUEVAxrFloYOAVwJ+rvGI1lsopArdJly8QXClT9lkvOxQszMw/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/graphql-tools/node_modules/value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -1718,6 +1939,16 @@
       "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/http-errors": {
@@ -2053,6 +2284,13 @@
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -2082,6 +2320,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2539,6 +2790,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2572,6 +2849,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/proxy-addr": {
@@ -2637,6 +2926,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2672,6 +2968,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehackt": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.6.tgz",
+      "integrity": "sha512-l3WEzkt4ntlEc/IB3/mF6SRgNHA6zfQR7BlGOgBTOmx7IJJXojDASav+NsgXHFjHn+6RmwqsGPFgZpabWpeOdw==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/retry": {
@@ -2883,6 +3208,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/to-regex-range": {

--- a/apollo/package.json
+++ b/apollo/package.json
@@ -26,6 +26,7 @@
     "express-rate-limit": "^7.3.1",
     "graphql": "^16.9.0",
     "graphql-resolvers": "^0.4.2",
+    "graphql-tools": "^9.0.1",
     "helmet": "^7.1.0",
     "mongoose": "^8.4.3",
     "morgan": "^1.10.0",

--- a/apollo/src/graphql/resolvers/index.ts
+++ b/apollo/src/graphql/resolvers/index.ts
@@ -1,9 +1,11 @@
 import { mergeResolvers } from "@graphql-tools/merge";
 
 import userResolver from "./user";
+import relationshipResolver from "./relationship";
+import friendResolvers from "./relationship";
 
 // Merge all resolvers: Add more in the future if needed
 // e.g [userResolver, postResolver, channelResolver]
-const resolvers = mergeResolvers([userResolver]);
+const resolvers = mergeResolvers([userResolver, relationshipResolver]);
 
 export default resolvers;

--- a/apollo/src/graphql/resolvers/relationship.ts
+++ b/apollo/src/graphql/resolvers/relationship.ts
@@ -1,0 +1,57 @@
+import { IResolvers } from '@graphql-tools/utils';
+import RelationshipModel from "../../models/relationship";
+
+const relationshipResolvers: IResolvers = {
+    Query: {
+        getRelationshipType: async (_, { user_first_id, user_second_id }) => {
+            const relationship = await RelationshipModel.findOne({
+                '_id.user_first_id': user_first_id,
+                '_id.user_second_id': user_second_id,
+            });
+
+            return relationship ? relationship.type : null;
+        },
+    },
+    Mutation: {
+        createRelationship: async (_, { user_first_id, user_second_id, type }) => {
+            const relationship = new RelationshipModel({
+                _id: {
+                    user_first_id,
+                    user_second_id,
+                },
+                type,
+            });
+
+            await relationship.save();
+
+            return relationship;
+        },
+
+        updateRelationship: async (_, { user_first_id, user_second_id, type }) => {
+            const relationship = await RelationshipModel.findOne({
+                '_id.user_first_id': user_first_id,
+                '_id.user_second_id': user_second_id,
+            });
+
+            if (!relationship) {
+                return null;
+            }
+
+            relationship.type = type;
+            await relationship.save();
+
+            return relationship;
+        },
+
+        deleteRelationship: async (_, { user_first_id, user_second_id }) => {
+            const relationship = await RelationshipModel.findOneAndDelete({
+                '_id.user_first_id': user_first_id,
+                '_id.user_second_id': user_second_id,
+            });
+
+            return relationship;
+        },
+    },
+};
+
+export default relationshipResolvers;

--- a/apollo/src/graphql/resolvers/user.ts
+++ b/apollo/src/graphql/resolvers/user.ts
@@ -2,8 +2,9 @@ import { UserInputError } from "apollo-server";
 import { combineResolvers } from "graphql-resolvers";
 import UserModel from "../../models/user";
 import bcrypt from "bcryptjs";
+import { IResolvers } from '@graphql-tools/utils';
 
-const userResolvers = {
+const userResolvers: IResolvers = {
   Query: {
     users: combineResolvers(async (_, __, { models }) => {
       const users = await models.UserModel.findAll();

--- a/apollo/src/graphql/typedefs/index.ts
+++ b/apollo/src/graphql/typedefs/index.ts
@@ -3,6 +3,8 @@ import { mergeTypeDefs } from "@graphql-tools/merge";
 
 import userSchema from "./user";
 
+import relationshipSchema from "./relationship";
+
 const linkedSchema = gql`
   type Query {
     _: Boolean
@@ -14,6 +16,6 @@ const linkedSchema = gql`
 
 // Merge all typeDefs: Add more in the future if needed
 // e.g [userSchema, postSchema, channelSchema]
-const typeDefs = mergeTypeDefs([linkedSchema, userSchema]);
+const typeDefs = mergeTypeDefs([linkedSchema, userSchema, relationshipSchema]);
 
 export default typeDefs;

--- a/apollo/src/graphql/typedefs/relationship.ts
+++ b/apollo/src/graphql/typedefs/relationship.ts
@@ -1,0 +1,33 @@
+import { gql } from "apollo-server-express";
+
+export default gql`
+  type Relationship {
+    _id: IDPair
+    type: RelationshipType
+    created_at: String
+    last_modified: String
+  }
+
+  type IDPair {
+    user_first_id: ID
+    user_second_id: ID
+  }
+
+  enum RelationshipType {
+    PENDING_FIRST_SECOND
+    PENDING_SECOND_FIRST
+    FRIEND
+    BLOCK_FIRST_SECOND
+    BLOCK_SECOND_FIRST
+  }
+  
+  extend type Query {
+    getRelationshipType(user_first_id: ID!, user_second_id: ID!): RelationshipType
+  }
+  
+  extend type Mutation {
+      createRelationship(user_first_id: ID!, user_second_id: ID!, type: RelationshipType!): Relationship
+      updateRelationship(user_first_id: ID!, user_second_id: ID!, type: RelationshipType!): Relationship
+      deleteRelationship(user_first_id: ID!, user_second_id: ID!): Relationship
+  }
+`;

--- a/apollo/src/models/relationship.ts
+++ b/apollo/src/models/relationship.ts
@@ -1,0 +1,36 @@
+import mongoose, { model, Schema } from "mongoose";
+import validator from "validator";
+
+interface IRelationship {
+    _id: { user_first_id: string, user_second_id: string };
+    type: "PENDING_FIRST_SECOND" | "PENDING_SECOND_FIRST" | "FRIEND" | "BLOCK_FIRST_SECOND" | "BLOCK_SECOND_FIRST";
+    last_modified: Date;
+}
+
+const relationshipSchema = new Schema<IRelationship>(
+    {
+        _id: {
+            user_first_id: {
+                type: String,
+                required: true,
+            },
+            user_second_id: {
+                type: String,
+                required: true,
+            },
+        },
+        type: {
+            type: String,
+            enum: ["PENDING_FIRST_SECOND", "PENDING_SECOND_FIRST", "FRIEND", "BLOCK_FIRST_SECOND", "BLOCK_SECOND_FIRST"],
+            required: true,
+        },
+        last_modified: {
+            type: Date,
+            default: Date.now,
+        },
+    },
+    { timestamps: true, _id: false }
+);
+
+const RelationshipModel = mongoose.model<IRelationship>("Relationship", relationshipSchema);
+export default RelationshipModel;


### PR DESCRIPTION
In this pull request, I have implemented user relationship model that has the following schema
- `_id`: composite primary key of `user_first_id` and `user_second_id`
- `type`: relationship type between the 2 users
    - `PENDING_FIRST_SECOND`
    - `PENDING_SECOND_FIRST`
    - `FRIEND`
    - `BLOCK_FIRST_SECOND`
    - `BLOCK_SECOND_FIRST`
- `created_at`
- `last_modified`

And the 5 API endpoints
- `POST /api/v1/friends/:id`: Add user with `id` as friend (Send friend request).
- `DELETE /api/v1/friends/:id`: Remove user `id` from friend list.
- `POST /api/v1/friends/accept/:id`: Accept friend request from user `id`.
- `DELETE /api/v1/friends/cancel/sent/:id`: Cancel sent friend request to user `id`.
- `DELETE /api/v1/friends/cancel/received/:id`: Cancel received friend request from user `id`.

All the API endpoints have been tested locally on my computer.

![Screen Shot 2024-07-13 at 10 14 59](https://github.com/user-attachments/assets/82761678-cfd0-46bd-89d8-c9c671f11015)
