### PR TITLE
BE-27: Implement block/unblock users API endpoints

### DIFF
--- a/api/src/controllers/friend.ts
+++ b/api/src/controllers/friend.ts
@@ -27,6 +27,20 @@ const getRelationshipType = async (
   return response;
 };
 
+const deleteRelationship = async (user_first_id: string, user_second_id: string) => {
+  if (user_first_id > user_second_id) {
+    const temp = user_first_id;
+    user_first_id = user_second_id;
+    user_second_id = temp;
+  }
+  const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+    user_first_id: user_first_id,
+    user_second_id: user_second_id,
+  });
+
+  return response;
+}
+
 /* Friend Management */
 
 // Add user with `id` as friend (Send friend request).
@@ -196,19 +210,9 @@ export const cancelFriendRequest = async (
       });
     }
 
-    if (current_user < friend && relationshipType == "PENDING_FIRST_SECOND") {
-      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
-        user_first_id: current_user,
-        user_second_id: friend,
-      });
-    } else if (
-      current_user > friend &&
-      relationshipType == "PENDING_SECOND_FIRST"
-    ) {
-      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
-        user_first_id: friend,
-        user_second_id: current_user,
-      });
+    if ((current_user < friend && relationshipType == "PENDING_FIRST_SECOND") ||
+        (current_user > friend && relationshipType == "PENDING_SECOND_FIRST")) {
+      const response = await deleteRelationship(current_user, friend);
     } else {
       return res.status(400).json({
         message: "You cannot cancel friend request to this user.",
@@ -255,19 +259,9 @@ export const cancelReceivedFriendRequest = async (
       });
     }
 
-    if (current_user > friend && relationshipType == "PENDING_FIRST_SECOND") {
-      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
-        user_first_id: friend,
-        user_second_id: current_user,
-      });
-    } else if (
-      current_user < friend &&
-      relationshipType == "PENDING_SECOND_FIRST"
-    ) {
-      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
-        user_first_id: current_user,
-        user_second_id: friend,
-      });
+    if ((current_user > friend && relationshipType == "PENDING_FIRST_SECOND") ||
+      (current_user < friend && relationshipType == "PENDING_SECOND_FIRST")) {
+      const response = await deleteRelationship(current_user, friend);
     } else {
       return res.status(400).json({
         message: "You cannot cancel received friend request from this user.",
@@ -315,10 +309,7 @@ export const removeFriend = async (
     }
 
     if (relationshipType == "FRIEND") {
-      const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
-        user_first_id: current_user,
-        user_second_id: friend,
-      });
+      const response = await deleteRelationship(current_user, friend);
     } else {
       return res.status(400).json({
         message: "You cannot remove this user as a friend.",
@@ -327,6 +318,152 @@ export const removeFriend = async (
 
     return res.status(200).json({
       message: "Friend removed.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+/* Block/Unblock users */
+// Block user with `id`
+export const blockUser = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot block yourself.",
+      });
+    }
+
+    let user_first_id = current_user;
+    let user_second_id = friend;
+
+    if (current_user > friend) {
+      user_first_id = friend;
+      user_second_id = current_user;
+    }
+
+    const relationshipType = await getRelationshipType(user_first_id, user_second_id)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if ((user_first_id == current_user && relationshipType == "BLOCK_FIRST_SECOND") ||
+        (user_first_id == friend && relationshipType == "BLOCK_SECOND_FIRST")) {
+      return res.status(400).json({
+        message: "You have already blocked this user.",
+      });
+    }
+
+    if ((user_first_id == friend && relationshipType == "BLOCK_FIRST_SECOND") ||
+        (user_first_id == current_user && relationshipType == "BLOCK_SECOND_FIRST")) {
+      return res.status(400).json({
+        message: "You have already been blocked by this user.",
+      });
+    }
+
+    if (!relationshipType) {
+      if (user_first_id == current_user) {
+        const response = await graphQLClient().request(CREATE_RELATIONSHIP, {
+          user_first_id: current_user,
+          user_second_id: friend,
+          type: "BLOCK_FIRST_SECOND",
+        });
+      } else {
+        const response = await graphQLClient().request(CREATE_RELATIONSHIP, {
+          user_first_id: friend,
+          user_second_id: current_user,
+          type: "BLOCK_SECOND_FIRST",
+        });
+      }
+    } else {
+      if (user_first_id == current_user) {
+        const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
+          user_first_id: current_user,
+          user_second_id: friend,
+          type: "BLOCK_FIRST_SECOND",
+        });
+      } else {
+        const response = await graphQLClient().request(UPDATE_RELATIONSHIP, {
+          user_first_id: friend,
+          user_second_id: current_user,
+          type: "BLOCK_SECOND_FIRST",
+        });
+      }
+    }
+
+    return res.status(200).json({
+      message: "User blocked.",
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// Unblock user with `id`
+export const unblockUser = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const current_user = req.params.uid;
+    const friend = req.params.id;
+
+    if (current_user == friend) {
+      return res.status(400).json({
+        message: "You cannot unblock yourself.",
+      });
+    }
+
+    let user_first_id = current_user;
+    let user_second_id = friend;
+
+    if (current_user > friend) {
+      user_first_id = friend;
+      user_second_id = current_user;
+    }
+
+    const relationshipType = await getRelationshipType(user_first_id, user_second_id)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
+
+    if (!relationshipType) {
+      return res.status(400).json({
+        message: "You have not blocked this user.",
+      });
+    }
+
+    if ((user_first_id == current_user && relationshipType != "BLOCK_FIRST_SECOND") ||
+        (user_first_id == friend && relationshipType != "BLOCK_SECOND_FIRST")) {
+      return res.status(400).json({
+        message: "You have not blocked this user.",
+      });
+    }
+
+    const response = await deleteRelationship(user_first_id, user_second_id);
+
+    return res.status(200).json({
+      message: "User unblocked.",
     });
   } catch (error) {
     return res.status(500).json({
@@ -337,6 +474,8 @@ export const removeFriend = async (
 
 /* Listing and Queries */
 
+// Get user relationship with `id`
+// Returns: "NOT-FRIEND" | "REQUEST-SENT" | "REQUEST-RECEIVED" | "FRIEND" | "BLOCK"
 export const getRelationshipTypeApi = async (
   req: express.Request,
   res: express.Response,
@@ -354,19 +493,42 @@ export const getRelationshipTypeApi = async (
       user_second_id = current_user;
     }
 
-    const { getRelationshipType: response } = await graphQLClient().request(
-      GET_RELATIONSHIP_TYPE,
-      {
-        user_first_id: user_first_id,
-        user_second_id: user_second_id,
-      }
-    );
+    const relationshipType = await getRelationshipType(user_first_id, user_second_id)
+      .then((res) => {
+        return res;
+      })
+      .catch((err) => {
+        return null;
+      });
 
-    if (!response) {
-      return res.status(200).json({ type: "NOT-FRIEND" });
+    if (!relationshipType) {
+        return res.status(200).json({"type": "NOT-FRIEND"});
     }
 
-    return res.status(200).json({ type: response });
+    if (user_first_id == current_user) {
+      if (relationshipType == "PENDING_FIRST_SECOND") {
+        return res.status(200).json({"type": "REQUEST-SENT"});
+      } else if (relationshipType == "PENDING_SECOND_FIRST") {
+        return res.status(200).json({"type": "REQUEST-RECEIVED"});
+      } else if (relationshipType == "FRIEND") {
+        return res.status(200).json({"type": "FRIEND"});
+      } else if (relationshipType == "BLOCK_FIRST_SECOND" || relationshipType == "BLOCK_SECOND_FIRST") {
+        return res.status(200).json({"type": "BLOCK"});
+      }
+    } else {
+      if (relationshipType == "PENDING_FIRST_SECOND") {
+        return res.status(200).json({"type": "REQUEST-RECEIVED"});
+      } else if (relationshipType == "PENDING_SECOND_FIRST") {
+        return res.status(200).json({"type": "REQUEST-SENT"});
+      } else if (relationshipType == "FRIEND") {
+        return res.status(200).json({"type": "FRIEND"});
+      } else if (relationshipType == "BLOCK_SECOND_FIRST" || relationshipType == "BLOCK_FIRST_SECOND") {
+        return res.status(200).json({"type": "BLOCK"});
+      }
+    }
+
+    return res.status(200).json({"type": "UNDEFINED"});
+
   } catch (error) {
     return res.status(500).json({
       message: error.message,

--- a/api/src/routes/friend.ts
+++ b/api/src/routes/friend.ts
@@ -1,5 +1,13 @@
-import { Request, Response, NextFunction, Router } from "express";
-import {addFriend, acceptFriend, cancelFriendRequest, cancelReceivedFriendRequest, removeFriend, getRelationshipTypeApi } from "../controllers/friend";
+import { Router } from "express";
+import {
+  addFriend,
+  acceptFriend,
+  cancelFriendRequest,
+  cancelReceivedFriendRequest,
+  removeFriend,
+  blockUser,
+  unblockUser,
+  getRelationshipTypeApi } from "../controllers/friend";
 import { authMiddleware } from "../utils/authMiddleware";
 
 
@@ -16,6 +24,12 @@ friendRouter.delete('/friends/cancel/sent/:id', authMiddleware, cancelFriendRequ
 friendRouter.delete('/friends/cancel/received/:id', authMiddleware, cancelReceivedFriendRequest);
 // remove user with `id` from friends
 friendRouter.delete('/friends/:id', authMiddleware, removeFriend);
+
+/* Block/Unblock */
+// block user with `id`
+friendRouter.post('/block/:id', authMiddleware, blockUser);
+// unblock user with `id`
+friendRouter.delete('/block/:id', authMiddleware, unblockUser);
 
 /* Listing and Queries */
 friendRouter.get("/relationship/:id", authMiddleware, getRelationshipTypeApi);


### PR DESCRIPTION
In this pull request, I have implemented 2 API endpoints
- `POST /api/v1/block/:id`: Block user `id`
    - If the user with `id` is already blocked by the current user, nothing will happen
    - If the user with `id` has already blocked the current user, nothing will happen
    - Otherwise, set the relationship of the current user with the user with `id` to block.
- `DELETE /api/v1/block/:id`: Unblock user `id`
    - If the user with id is already blocked by the current user, unblock him/her.
    - Otherwise, do nothing.

The 2 API endpoints have been tested locally using Postman and worked correctly.