### PR TITLE
BE-28: Implement Listing and Queries API endpoints for friend system

### DIFF
--- a/api/src/controllers/friend.ts
+++ b/api/src/controllers/friend.ts
@@ -1,39 +1,21 @@
 import express from "express";
 import graphQLClient from "../utils/graphql";
-import { GET_RELATIONSHIP_TYPE } from "../graphql/queries";
 import {
-  CREATE_RELATIONSHIP,
-  UPDATE_RELATIONSHIP,
-  DELETE_RELATIONSHIP,
-} from "../graphql/mutations";
+  GET_ALL_FRIENDS,
+  GET_BLOCKED_USERS,
+  GET_RECEIVED_FRIEND_REQUESTS,
+  GET_RELATIONSHIP_TYPE,
+  GET_SENT_FRIEND_REQUESTS
+} from "../graphql/queries";
+import {CREATE_RELATIONSHIP, DELETE_RELATIONSHIP, UPDATE_RELATIONSHIP} from "../graphql/mutations";
 
-const getRelationshipType = async (
-  user_first_id: string,
-  user_second_id: string
-) => {
+const getRelationshipType = async (user_first_id: string, user_second_id: string) => {
   if (user_first_id > user_second_id) {
     const temp = user_first_id;
     user_first_id = user_second_id;
     user_second_id = temp;
   }
-  const { getRelationshipType: response } = await graphQLClient().request(
-    GET_RELATIONSHIP_TYPE,
-    {
-      user_first_id: user_first_id,
-      user_second_id: user_second_id,
-    }
-  );
-
-  return response;
-};
-
-const deleteRelationship = async (user_first_id: string, user_second_id: string) => {
-  if (user_first_id > user_second_id) {
-    const temp = user_first_id;
-    user_first_id = user_second_id;
-    user_second_id = temp;
-  }
-  const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+  const { getRelationshipType: response } = await graphQLClient().request(GET_RELATIONSHIP_TYPE, {
     user_first_id: user_first_id,
     user_second_id: user_second_id,
   });
@@ -47,12 +29,10 @@ const deleteRelationship = async (user_first_id: string, user_second_id: string)
     user_first_id = user_second_id;
     user_second_id = temp;
   }
-  const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+  return await graphQLClient().request(DELETE_RELATIONSHIP, {
     user_first_id: user_first_id,
     user_second_id: user_second_id,
   });
-
-  return response;
 }
 
 /* Friend Management */
@@ -487,6 +467,102 @@ export const unblockUser = async (
 };
 
 /* Listing and Queries */
+
+// List all friends
+export const getAllFriends = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const user_id = req.params.uid;
+
+    const { getAllFriends: response } = await graphQLClient().request(GET_ALL_FRIENDS, {
+      user_id: user_id,
+    });
+
+    return res.status(200).json({
+      friends: response,
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// List received friend requests
+export const getReceivedFriendRequests = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const user_id = req.params.uid;
+
+    const { getReceivedFriendRequests: response } = await graphQLClient().request(GET_RECEIVED_FRIEND_REQUESTS, {
+      user_id: user_id,
+    });
+
+    return res.status(200).json({
+      requests: response,
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// List sent friend requests
+export const getSentFriendRequests = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const user_id = req.params.uid;
+
+    const { getSentFriendRequests: response } = await graphQLClient().request(GET_SENT_FRIEND_REQUESTS, {
+      user_id: user_id,
+    });
+
+    return res.status(200).json({
+      requests: response,
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
+
+// List blocked users
+export const getBlockedUsers = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  try {
+    const user_id = req.params.uid;
+
+    const { getBlockedUsers: response } = await graphQLClient().request(GET_BLOCKED_USERS, {
+      user_id: user_id,
+    });
+
+    return res.status(200).json({
+      blocked: response,
+    });
+
+  } catch (error) {
+    return res.status(500).json({
+      message: error.message,
+    });
+  }
+};
 
 // Get user relationship with `id`
 // Returns: "NOT-FRIEND" | "REQUEST-SENT" | "REQUEST-RECEIVED" | "FRIEND" | "BLOCK"

--- a/api/src/controllers/friend.ts
+++ b/api/src/controllers/friend.ts
@@ -41,6 +41,20 @@ const deleteRelationship = async (user_first_id: string, user_second_id: string)
   return response;
 }
 
+const deleteRelationship = async (user_first_id: string, user_second_id: string) => {
+  if (user_first_id > user_second_id) {
+    const temp = user_first_id;
+    user_first_id = user_second_id;
+    user_second_id = temp;
+  }
+  const response = await graphQLClient().request(DELETE_RELATIONSHIP, {
+    user_first_id: user_first_id,
+    user_second_id: user_second_id,
+  });
+
+  return response;
+}
+
 /* Friend Management */
 
 // Add user with `id` as friend (Send friend request).

--- a/api/src/graphql/queries.ts
+++ b/api/src/graphql/queries.ts
@@ -52,3 +52,39 @@ export const GET_RELATIONSHIP_TYPE = gql`
     getRelationshipType(user_first_id: $user_first_id, user_second_id: $user_second_id)
   }
 `;
+
+export const GET_ALL_FRIENDS = gql`
+  query getAllFriends($user_id: ID!) {
+    getAllFriends(user_id: $user_id) {
+      id
+      username
+    }
+  }
+`;
+
+export const GET_RECEIVED_FRIEND_REQUESTS = gql`
+  query getReceivedFriendRequests($user_id: ID!) {
+    getReceivedFriendRequests(user_id: $user_id) {
+      id
+      username
+    }
+  }
+`;
+
+export const GET_SENT_FRIEND_REQUESTS = gql`
+  query getSentFriendRequests($user_id: ID!) {
+    getSentFriendRequests(user_id: $user_id) {
+      id
+      username
+    }
+  }
+`;
+
+export const GET_BLOCKED_USERS = gql`
+  query getBlockedUsers($user_id: ID!) {
+    getBlockedUsers(user_id: $user_id) {
+      id
+      username
+    }
+  }
+`;

--- a/api/src/routes/friend.ts
+++ b/api/src/routes/friend.ts
@@ -7,6 +7,10 @@ import {
   removeFriend,
   blockUser,
   unblockUser,
+  getAllFriends,
+  getReceivedFriendRequests,
+  getSentFriendRequests,
+  getBlockedUsers,
   getRelationshipTypeApi } from "../controllers/friend";
 import { authMiddleware } from "../utils/authMiddleware";
 
@@ -32,6 +36,16 @@ friendRouter.post('/block/:id', authMiddleware, blockUser);
 friendRouter.delete('/block/:id', authMiddleware, unblockUser);
 
 /* Listing and Queries */
+// get all friends of user with `id`
+friendRouter.get("/friends/", authMiddleware, getAllFriends);
+// get all received friend requests of the current user
+friendRouter.get("/friends/requests/received", authMiddleware, getReceivedFriendRequests);
+// get all sent friend requests of the current user
+friendRouter.get("/friends/requests/sent", authMiddleware, getSentFriendRequests);
+// get all blocked users of the current user
+friendRouter.get("/block/", authMiddleware, getBlockedUsers);
+
+// get relationship type between the current user and user with `id`
 friendRouter.get("/relationship/:id", authMiddleware, getRelationshipTypeApi);
 
 

--- a/apollo/src/graphql/resolvers/relationship.ts
+++ b/apollo/src/graphql/resolvers/relationship.ts
@@ -1,5 +1,6 @@
 import { IResolvers } from '@graphql-tools/utils';
 import RelationshipModel from "../../models/relationship";
+import UserModel from "../../models/user";
 
 const relationshipResolvers: IResolvers = {
     Query: {
@@ -10,6 +11,80 @@ const relationshipResolvers: IResolvers = {
             });
 
             return relationship ? relationship.type : null;
+        },
+
+        getAllFriends: async (_, { user_id }) => {
+            const relationships = await RelationshipModel.find({
+                $or: [
+                    { '_id.user_first_id': user_id, type: 'FRIEND' },
+                    { '_id.user_second_id': user_id, type: 'FRIEND' },
+                ],
+            });
+
+            // Use Promise.all to fetch all friends in parallel
+            const friends = await Promise.all(relationships.map(async ({ _id }) => {
+                const friendId = _id.user_first_id === user_id ? _id.user_second_id : _id.user_first_id;
+                const friend = await UserModel.findById(friendId); // Fetch the friend from the UserModel
+                return { id: friendId, username: friend.username }; // Return the id and username
+            }));
+
+            return friends;
+        },
+
+        getReceivedFriendRequests: async (_, { user_id }) => {
+            const relationships = await RelationshipModel.find({
+                $or: [
+                    { '_id.user_second_id': user_id, type: 'PENDING_FIRST_SECOND' },
+                    { '_id.user_first_id': user_id, type: 'PENDING_SECOND_FIRST' },
+                ],
+            });
+
+            // Use Promise.all to fetch all friends in parallel
+            const friends = await Promise.all(relationships.map(async ({ _id }) => {
+                const friendId = _id.user_first_id === user_id ? _id.user_second_id : _id.user_first_id;
+                const friend = await UserModel.findById(friendId); // Fetch the friend from the UserModel
+                return { id: friendId, username: friend.username }; // Return the id and username
+            }));
+
+            return friends;
+        },
+
+        getSentFriendRequests: async (_, { user_id }) => {
+            const relationships = await RelationshipModel.find({
+                $or: [
+                    { '_id.user_first_id': user_id, type: 'PENDING_FIRST_SECOND' },
+                    { '_id.user_second_id': user_id, type: 'PENDING_SECOND_FIRST' },
+                ],
+            });
+
+            console.log(relationships);
+
+            // Use Promise.all to fetch all friends in parallel
+            const friends = await Promise.all(relationships.map(async ({ _id }) => {
+                const friendId = _id.user_first_id === user_id ? _id.user_second_id : _id.user_first_id;
+                const friend = await UserModel.findById(friendId); // Fetch the friend from the UserModel
+                return { id: friendId, username: friend.username }; // Return the id and username
+            }));
+
+            return friends;
+        },
+
+        getBlockedUsers: async (_, { user_id }) => {
+            const relationships = await RelationshipModel.find({
+                $or: [
+                    { '_id.user_first_id': user_id, type: 'BLOCK_FIRST_SECOND' },
+                    { '_id.user_second_id': user_id, type: 'BLOCK_SECOND_FIRST' },
+                ],
+            });
+
+            // Use Promise.all to fetch all friends in parallel
+            const friends = await Promise.all(relationships.map(async ({ _id }) => {
+                const friendId = _id.user_first_id === user_id ? _id.user_second_id : _id.user_first_id;
+                const friend = await UserModel.findById(friendId); // Fetch the friend from the UserModel
+                return { id: friendId, username: friend.username }; // Return the id and username
+            }));
+
+            return friends;
         },
     },
     Mutation: {

--- a/apollo/src/graphql/typedefs/relationship.ts
+++ b/apollo/src/graphql/typedefs/relationship.ts
@@ -23,6 +23,10 @@ export default gql`
   
   extend type Query {
     getRelationshipType(user_first_id: ID!, user_second_id: ID!): RelationshipType
+    getAllFriends(user_id: ID!): [User]
+    getReceivedFriendRequests(user_id: ID!): [User]
+    getSentFriendRequests(user_id: ID!): [User]
+    getBlockedUsers(user_id: ID!): [User]
   }
   
   extend type Mutation {


### PR DESCRIPTION
In this pull request, we will implement the following 5 API endpoints.
- `GET /api/v1/friends`: List all friends
- `GET /api/v1/friends/requests/received`: List received friend requests
- `GET /api/v1/friends/requests/sent`: List sent friend requests
- `GET /api/v1/block`: List blocked users
- `GET /api/v1/relationship/:id`: Get user relationship type with user `id`. The response will be a JSON with the value in the following
    - `REQUEST-SENT`
    - `REQUEST-RECEIVED`
    - `FRIEND`
    - `BLOCK`
    - `NOT-FRIEND`

All the 5 API endpoints have tested locally using Postman and worked correctly.