### PR TITLE
BE-33: Implement the User Settings

### DIFF
--- a/api/src/controllers/settings.ts
+++ b/api/src/controllers/settings.ts
@@ -1,0 +1,146 @@
+import express from "express";
+import graphQLClient from "../utils/graphql";
+import { settingsMutations } from "../graphql/mutations";
+import { settingsQueries } from "../graphql/queries";
+import { parse } from "path";
+
+const getUserSettings = async (userId: string) => {
+  const response = await graphQLClient().request(
+    settingsQueries.GET_USER_SETTINGS,
+    {
+      userId: userId,
+    }
+  );
+
+  return response.getUserSettings;
+};
+
+/* ======================================== */
+
+export const getSettings = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const currentUser = req.params.uid;
+
+  try {
+    const settings = await getUserSettings(currentUser).catch(() => null);
+
+    let parsedSettings = null;
+    try {
+      parsedSettings = JSON.parse(settings.settings);
+    } catch (error) {
+      return res
+        .status(400)
+        .json({ message: "Settings is not in JSON format !" });
+    }
+
+    return res.status(200).json({ ...parsedSettings });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const createSettings = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const currentUser = req.params.uid as string;
+  const { settings } = req.body as { settings: string };
+  let parsedSettings = null;
+
+  try {
+    const response = await graphQLClient().request(
+      settingsMutations.CREATE_USER_SETTINGS,
+      {
+        input: {
+          userId: currentUser,
+          settings: JSON.stringify(req.body),
+        },
+      }
+    );
+
+    return res.status(200).json({
+      message: "Settings created successfully !",
+      settings: parsedSettings,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateSettings = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const currentUser = req.params.uid as string;
+
+  try {
+    const response = await graphQLClient().request(
+      settingsMutations.UPDATE_USER_SETTINGS,
+      {
+        input: {
+          userId: currentUser,
+          settings: JSON.stringify(req.body),
+        },
+      }
+    );
+
+    return res.status(200).json({
+      message: "Settings updated successfully !",
+      settings: req.body,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteSettings = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const currentUser = req.params.uid;
+
+  try {
+    const response = await graphQLClient().request(
+      settingsMutations.DELETE_USER_SETTINGS,
+      {
+        userId: currentUser,
+      }
+    );
+
+    return res.status(200).json({ message: "Settings deleted successfully !" });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const resetSettings = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const currentUser = req.params.uid;
+
+  try {
+    const response = await graphQLClient().request(
+      settingsMutations.RESTORE_USER_SETTINGS,
+      {
+        userId: currentUser,
+      }
+    );
+
+    const parsedSettings = JSON.parse(response.restoreUserSettings.settings);
+
+    return res.status(200).json({
+      message: "Settings restored successfully !",
+      settings: parsedSettings,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/api/src/controllers/user.ts
+++ b/api/src/controllers/user.ts
@@ -1,7 +1,11 @@
 import express from "express";
 import graphQLClient from "../utils/graphql";
 import { CREATE_USER, UPDATE_REFRESH_TOKEN } from "../graphql/mutations";
-import { GET_USER_BY_EMAIL, LOGIN_USER, GET_USER_BY_USERNAME } from "../graphql/queries";
+import {
+  GET_USER_BY_EMAIL,
+  LOGIN_USER,
+  GET_USER_BY_USERNAME,
+} from "../graphql/queries";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 
@@ -42,6 +46,8 @@ const getUserByUsername = async (username: string) => {
 
   return response.getUserByUsername;
 };
+
+// ========================================
 
 export const createUser = async (
   req: express.Request,

--- a/api/src/graphql/mutations.ts
+++ b/api/src/graphql/mutations.ts
@@ -25,9 +25,48 @@ export const UPDATE_REFRESH_TOKEN = gql`
   }
 `;
 
+export const settingsMutations = {
+  CREATE_USER_SETTINGS: gql`
+    mutation createUserSettings($input: CreateUserSettingsInput!) {
+      createUserSettings(input: $input) {
+        settings
+      }
+    }
+  `,
+  UPDATE_USER_SETTINGS: gql`
+    mutation updateUserSettings($input: UpdateUserSettingsInput!) {
+      updateUserSettings(input: $input) {
+        settings
+      }
+    }
+  `,
+  DELETE_USER_SETTINGS: gql`
+    mutation deleteUserSettings($userId: ID!) {
+      deleteUserSettings(userId: $userId) {
+        settings
+      }
+    }
+  `,
+  RESTORE_USER_SETTINGS: gql`
+    mutation restoreUserSettings($userId: ID!) {
+      restoreUserSettings(userId: $userId) {
+        settings
+      }
+    }
+  `,
+};
+
 export const CREATE_RELATIONSHIP = gql`
-  mutation createRelationship($user_first_id: ID!, $user_second_id: ID!, $type: RelationshipType!) {
-    createRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id, type: $type) {
+  mutation createRelationship(
+    $user_first_id: ID!
+    $user_second_id: ID!
+    $type: RelationshipType!
+  ) {
+    createRelationship(
+      user_first_id: $user_first_id
+      user_second_id: $user_second_id
+      type: $type
+    ) {
       _id {
         user_first_id
         user_second_id
@@ -40,8 +79,16 @@ export const CREATE_RELATIONSHIP = gql`
 `;
 
 export const UPDATE_RELATIONSHIP = gql`
-  mutation updateRelationship($user_first_id: ID!, $user_second_id: ID!, $type: RelationshipType!) {
-    updateRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id, type: $type) {
+  mutation updateRelationship(
+    $user_first_id: ID!
+    $user_second_id: ID!
+    $type: RelationshipType!
+  ) {
+    updateRelationship(
+      user_first_id: $user_first_id
+      user_second_id: $user_second_id
+      type: $type
+    ) {
       _id {
         user_first_id
         user_second_id
@@ -55,7 +102,10 @@ export const UPDATE_RELATIONSHIP = gql`
 
 export const DELETE_RELATIONSHIP = gql`
   mutation deleteRelationship($user_first_id: ID!, $user_second_id: ID!) {
-    deleteRelationship(user_first_id: $user_first_id, user_second_id: $user_second_id) {
+    deleteRelationship(
+      user_first_id: $user_first_id
+      user_second_id: $user_second_id
+    ) {
       _id {
         user_first_id
         user_second_id

--- a/api/src/graphql/queries.ts
+++ b/api/src/graphql/queries.ts
@@ -47,6 +47,16 @@ export const LOGIN_USER = gql`
   }
 `;
 
+export const settingsQueries = {
+  GET_USER_SETTINGS: gql`
+    query getUserSettings($userId: ID!) {
+      getUserSettings(userId: $userId) {
+        settings
+      }
+    }
+  `,
+};
+
 export const GET_RELATIONSHIP_TYPE = gql`
   query getRelationshipType($user_first_id: ID!, $user_second_id: ID!) {
     getRelationshipType(user_first_id: $user_first_id, user_second_id: $user_second_id)

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { authMiddleware } from "../utils/authMiddleware";
+import {
+  getSettings,
+  updateSettings,
+  resetSettings,
+} from "../controllers/settings";
+
+const settingsRouter = Router();
+
+// Get user settings
+settingsRouter.get("/settings/", authMiddleware, getSettings);
+
+// Create user settings
+// settingsRouter.post("/settings/", authMiddleware, createSettings);
+
+// Update user settings
+settingsRouter.put("/settings/", authMiddleware, updateSettings);
+
+// Restore user settings
+settingsRouter.put("/settings/reset/", authMiddleware, resetSettings);
+
+// Delete user settings
+// settingsRouter.delete("/settings/", authMiddleware, deleteSettings);
+
+export default settingsRouter;

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction, Router } from "express";
 import { createUser, loginUser, refresh, getMe } from "../controllers/user";
+import { get } from "http";
+import { log } from "console";
 const userRouter = Router();
 
 // Define your routes here
@@ -9,52 +11,16 @@ userRouter.get("/", (req: Request, res: Response, next: NextFunction) => {
   // Call next middleware
 });
 
-// /login route
-userRouter.post(
-  "/login",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await loginUser(req, res, next);
-    } catch (error) {
-      next(error);
-    }
-  }
-);
+// Login user
+userRouter.post("/login", loginUser);
 
-// /register route
-userRouter.post(
-  "/register",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await createUser(req, res, next);
-    } catch (error) {
-      next(error);
-    }
-  }
-);
+// Register user
+userRouter.post("/register", createUser);
 
-// /refresh route
-userRouter.post(
-  "/refresh",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await refresh(req, res, next);
-    } catch (error) {
-      next(error);
-    }
-  }
-);
+// Refresh token
+userRouter.post("/refresh", refresh);
 
-// /me route
-userRouter.get(
-  "/me",
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      await getMe(req, res, next);
-    } catch (error) {
-      next(error);
-    }
-  }
-);
+// Get user
+userRouter.get("/me", getMe);
 
 export default userRouter;

--- a/apollo/src/graphql/resolvers/index.ts
+++ b/apollo/src/graphql/resolvers/index.ts
@@ -1,11 +1,11 @@
 import { mergeResolvers } from "@graphql-tools/merge";
 
 import userResolver from "./user";
+import userSettingsResolvers from "./userSettings";
 import relationshipResolver from "./relationship";
-import friendResolvers from "./relationship";
 
 // Merge all resolvers: Add more in the future if needed
 // e.g [userResolver, postResolver, channelResolver]
-const resolvers = mergeResolvers([userResolver, relationshipResolver]);
+const resolvers = mergeResolvers([userResolver, userSettingsResolvers, relationshipResolver]);
 
 export default resolvers;

--- a/apollo/src/graphql/resolvers/userSettings.ts
+++ b/apollo/src/graphql/resolvers/userSettings.ts
@@ -1,0 +1,76 @@
+import { IResolvers } from "@graphql-tools/utils";
+import { UserInputError } from "apollo-server";
+import UserSettingsModel from "../../models/userSettings";
+import UserModel from "../../models/user";
+
+export const defaultSettings = JSON.stringify({
+  // Appearance
+  theme: "light",
+  language: "en",
+
+  // Friend requests
+  friendReqFromEveryone: true, // Allow friend requests from everyone
+  friendReqFromFoFriends: true, // Allow friend requests from friends of friends
+  friendReqFromServer: true, // Allow friend requests from server members
+
+  // Notification
+  enableNotif: true, // Enable notifications
+  notifSound: true, // Enable notification sound
+
+  // TODO: Add more later
+});
+
+const userSettingsResolvers: IResolvers = {
+  Query: {
+    getUserSettings: async (_, { userId }) => {
+      const userSettings = await UserSettingsModel.findOne({ userId });
+      if (!userSettings) {
+        throw new UserInputError("User settings not found!");
+      }
+      return userSettings;
+    },
+  },
+  Mutation: {
+    createUserSettings: async (_, { input }) => {
+      const { userId, settings } = input;
+      const user = await UserModel.findById(userId);
+      if (!user) {
+        throw new UserInputError("User not found!");
+      }
+      const userSettings = await UserSettingsModel.create({ userId, settings });
+      return userSettings;
+    },
+    updateUserSettings: async (_, { input }) => {
+      const { userId, settings } = input;
+      const userSettings = await UserSettingsModel.findOneAndUpdate(
+        { userId },
+        { settings },
+        { new: true }
+      );
+      if (!userSettings) {
+        throw new UserInputError("User settings not found!");
+      }
+      return userSettings;
+    },
+    deleteUserSettings: async (_, { userId }) => {
+      const userSettings = await UserSettingsModel.findOneAndDelete({ userId });
+      if (!userSettings) {
+        throw new UserInputError("User settings not found!");
+      }
+      return userSettings;
+    },
+    restoreUserSettings: async (_, { userId }) => {
+      const userSettings = await UserSettingsModel.findOneAndUpdate(
+        { userId },
+        { settings: defaultSettings },
+        { new: true }
+      );
+      if (!userSettings) {
+        throw new UserInputError("User settings not found!");
+      }
+      return userSettings;
+    },
+  },
+};
+
+export default userSettingsResolvers;

--- a/apollo/src/graphql/typedefs/index.ts
+++ b/apollo/src/graphql/typedefs/index.ts
@@ -2,7 +2,7 @@ import { gql } from "apollo-server-express";
 import { mergeTypeDefs } from "@graphql-tools/merge";
 
 import userSchema from "./user";
-
+import userSettingsSchema from "./userSettings";
 import relationshipSchema from "./relationship";
 
 const linkedSchema = gql`
@@ -16,6 +16,6 @@ const linkedSchema = gql`
 
 // Merge all typeDefs: Add more in the future if needed
 // e.g [userSchema, postSchema, channelSchema]
-const typeDefs = mergeTypeDefs([linkedSchema, userSchema, relationshipSchema]);
+const typeDefs = mergeTypeDefs([linkedSchema, userSchema, userSettingsSchema, relationshipSchema]);
 
 export default typeDefs;

--- a/apollo/src/graphql/typedefs/userSettings.ts
+++ b/apollo/src/graphql/typedefs/userSettings.ts
@@ -1,0 +1,39 @@
+import { gql } from "apollo-server-express";
+
+export default gql`
+  type User {
+    _id: ID!
+    username: String!
+    email: String!
+  }
+
+  type UserSettings {
+    _id: ID!
+    userId: ID!
+    user: User
+    settings: String
+    createdAt: String
+    updatedAt: String
+  }
+
+  input CreateUserSettingsInput {
+    userId: ID!
+    settings: String
+  }
+
+  input UpdateUserSettingsInput {
+    userId: ID!
+    settings: String
+  }
+
+  type Query {
+    getUserSettings(userId: ID!): UserSettings
+  }
+
+  type Mutation {
+    createUserSettings(input: CreateUserSettingsInput!): UserSettings
+    updateUserSettings(input: UpdateUserSettingsInput!): UserSettings
+    deleteUserSettings(userId: ID!): UserSettings
+    restoreUserSettings(userId: ID!): UserSettings
+  }
+`;

--- a/apollo/src/models/userSettings.ts
+++ b/apollo/src/models/userSettings.ts
@@ -1,0 +1,26 @@
+import mongoose, { model, Schema } from "mongoose";
+import validator from "validator";
+
+export interface IUserSettings {
+  userId: { type: Schema.Types.ObjectId };
+  settings: string;
+}
+
+const userSettingsSchema = new Schema<IUserSettings>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required!"],
+    },
+    settings: {
+      type: String,
+      default: "",
+      required: false,
+    },
+  },
+  { timestamps: true, id: false }
+);
+
+const UserSettingsModel = model<IUserSettings>("settings", userSettingsSchema);
+export default UserSettingsModel;


### PR DESCRIPTION
## What?
This pull request introduces a new set of API endpoints for managing user settings:

- `API/v1/settings (GET)`: Retrieves the current user's settings. It will return the JSON-parsed results of the settings only.
- `API/v1/settings (PATCH)`: Updates the current user's settings. It will return a message when updated successfully.
- `API/v1/settings/reset (PATCH)`: Restore the current user's settings to the original settings. It will return a message with JSON-parsed restored settings when restored successfully.

And also manage to update settings for the current user base (i.e., new settings) or create settings for new users.

## How?
- `GET /settings`: This endpoint will use Auth Middleware to identify users and retrieve their settings from the database. The retrieved settings data will be returned in the response body.
- `PATCH /settings`: This endpoint will accept user-provided updates to their settings data. It will validate the provided information and perform the update operation on the user's settings record.

The setting will also be automatically added when the users create an account successfully.

## Screenshot (Optional)
![Screenshot (91)](https://github.com/user-attachments/assets/7dab73d6-d566-4ac1-9e33-7ee692743a33)
![Screenshot (92)](https://github.com/user-attachments/assets/6b753d90-b951-4508-965d-b458663ece64)
![Screenshot (93)](https://github.com/user-attachments/assets/2439d979-b14d-4b2e-9905-ee3250de6e03)

## Tasks
- [X] Add /settings GET endpoint to retrieve user settings
- [X] Add /settings PATCH endpoint to update user settings
- [x] Add /settings/reset PATCH endpoint to restore user settings
- [X] Add initial settings to new users and add the missing settings to old users.