### PR TITLE
BE-45: Add a reverse proxy to manage access from outside of docker network (host machine)

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,7 @@
+# Use the official nginx base image
+FROM nginx:latest
+
+# Install netcat-openbsd
+RUN apt-get update && \
+    apt-get install -y netcat-openbsd && \
+    rm -rf /var/lib/apt/lists/*

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,6 @@ FROM node:16-slim
 WORKDIR /app
 
 ENV NODE_PATH ./dist
-ENV NODE_ENV production
 
 # EXPOSE 4000
 

--- a/apollo/Dockerfile
+++ b/apollo/Dockerfile
@@ -3,7 +3,6 @@ FROM node:16-slim
 WORKDIR /app
 
 ENV NODE_PATH ./dist
-ENV NODE_ENV development
 
 # EXPOSE 4000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 services:
   api:
     build: ./api
-    ports:
-      - '4001:4001'
+    networks:
+      - backend
     volumes:
       - ./api:/app
     command: npm start
@@ -11,10 +11,37 @@ services:
       - apollo
     environment:
       - GQL_SERVER_URL=http://apollo:4000/graphql
+      - NODE_ENV=${ENVIRONMENT}
+
   apollo:
     build: ./apollo
-    ports:
-      - '4000:4000'
+    networks:
+      - backend
     volumes:
       - ./apollo:/app
     command: npm start
+    environment:
+      - NODE_ENV=${ENVIRONMENT}
+
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    volumes:
+      - ./nginx.conf.template:/etc/nginx/conf.d/nginx.conf.template
+      - ./entrypoint.sh:/docker-entrypoint.d/entrypoint.sh
+      - ./wait-for-it.sh:/wait-for-it.sh
+    ports:
+      - "80:80"
+    networks:
+      - backend
+    environment:
+      - ENVIRONMENT=${ENVIRONMENT}
+    entrypoint: [ "/bin/sh", "-c" ]
+    command: [ "/wait-for-it.sh api:4001 apollo:4000 -- /docker-entrypoint.d/entrypoint.sh" ]
+    depends_on:
+      - api
+      - apollo
+
+networks:
+  backend:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Set the default value for ENVIRONMENT
+ENVIRONMENT=${ENVIRONMENT:-production}
+
+# Conditional logic to set the proxy_pass directive
+if [ "$ENVIRONMENT" = "development" ]; then
+  GRAPHQL_FORWARD='proxy_pass http://apollo:4000/graphql;'
+else
+  GRAPHQL_FORWARD='# GraphQL forwarding disabled in production'
+fi
+
+# Export the variable so it's available to envsubst
+export GRAPHQL_FORWARD
+
+# Substitute the variables in the nginx.conf.template and output to nginx.conf
+envsubst '${GRAPHQL_FORWARD}' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf
+
+# Execute the original nginx entrypoint with any passed arguments
+exec nginx -g 'daemon off;'

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,22 @@
+server {
+  listen 80;
+
+  location /subscriptions {
+      proxy_pass http://apollo:4000/subscriptions;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+  location /graphql {
+    ${GRAPHQL_FORWARD}
+  }
+
+  location / {
+    proxy_pass http://api:4001;
+  }
+}

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Function to wait for a single service
+wait_for_service() {
+    local HOST=$(echo $1 | cut -d : -f 1)
+    local PORT=$(echo $1 | cut -d : -f 2)
+
+    until nc -z $HOST $PORT; do
+        echo "Waiting for $HOST:$PORT to be available..."
+        sleep 3 # wait for 3 seconds before check again
+    done
+
+    echo "$HOST:$PORT is available."
+}
+
+# Main script logic
+
+# Process each host:port argument
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        --)
+            shift
+            break
+            ;;
+        *)
+            wait_for_service $1
+            shift
+            ;;
+    esac
+done
+
+# Execute the command if provided
+if [ -n "$1" ]; then
+    exec "$@"
+fi


### PR DESCRIPTION
# Context

Recently, we implemented subscriptions for the front end to connect to the GraphQL server to listen for user status and online presence updates. This leads us to a concern about managing access from the Internet to the Apollo Server. Here's an overview of our system flow:

- When the client (user) wants to interact with our server, they will interact with API endpoints exposed by the API server on port `4001`.

- The API server only processes our business and app logic, and should not have direct access to the database to read, modify, and delete the data in our Mobile Database.

- The Apollo server plays a crucial role in abstracting and interacting with our data. When the API server needs data from the database to process, it must obtain it from the Apollo server. Additionally, the Apollo server is our internal service and should not be exposed to the Mobile Frontend or the Internet, except for the endpoint `/subscriptions`, which sends data to the client when real-time updates are needed, making it the only part of the server exposed to the Internet.

However, the current system diagram does not support our current system flow.
![image](https://github.com/user-attachments/assets/9cc61823-b9ef-4b7c-bf6d-222ab87950aa)

In the current networking system, the Mobile Frontend and Internet can access the API Server through port `4001` and GraphQL through port `4000` without any restrictions. The `/graphql` endpoint is crucial, as it provides access to all of our queries and mutations that directly read, modify, and delete our data in the Mobile Database. To ensure security, we need to implement a method to manage access to our backend services (API server and Apollo server).

# Proposed Solution
![image](https://github.com/user-attachments/assets/1c2c4b26-2237-4c14-8bfe-44eece2fba11)

The mobile front end and the internet will communicate with the backend through port `80`. They can connect to the Apollo server through the `/subscriptions` endpoint, but access to the `/graphql` endpoint is not allowed. All requests that don't call to `/subscriptions` or `/graphql` are forwarded to the API server. This is accomplished using a reverse proxy with [NGINX](https://nginx.org/en/). NGINX is an HTTP and `reverse` proxy server that filters, validates requests, and forwards them to the appropriate service (for other usages, please refer to their [official documentation](https://nginx.org/en/docs/)). With NGINX, we can control access to our internal backend services based on our environment (development or production), configurations, etc.

In `development` mode, we can freely allow access to the Apollo server's `/graphql` endpoint for debugging, while in `production` mode, access from the Internet to `/graphql` is blocked.

# Acceptance Criteria

- Add a backend network for all Docker containers.

- Add NGINX reverse proxy server to process all requests from the mobile front end and the Internet. Valid requests are then forwarded to the right backend service (e.g. requests to `/subscriptions` and `/graphql` are forwarded to the Apollo server, whilst other requests are forwarded to the API server).

- Add `environment` variable that identifies the deployment stage (`development` or `production`).

- The NGINX reverse proxy server should listens to port `80`. That means mobile front end can access the backend service through port `80`.

# Usage
// To be updated

# CC
@mobile-apcs-ntploc21/mobile-developer