### PR TITLE
BE-64: Fix user profile update argument when send to GraphQL

### DIFF
--- a/api/src/controllers/user_profile.ts
+++ b/api/src/controllers/user_profile.ts
@@ -159,6 +159,19 @@ export const updateProfile = async (
     }
   }
 
+  // Prepare input object for GraphQL mutation
+  const input: {
+    display_name?: string;
+    about_me?: string;
+    avatar_url?: string;
+    banner_url?: string;
+  } = {
+    ...(display_name && { display_name }),
+    ...(about_me && { about_me }),
+    ...(avatar_url && { avatar_url }),
+    ...(banner_url && { banner_url }),
+  };
+
   try {
     const response = await graphQLClient().request(
       userProfileMutation.UPDATE_USER_PROFILE,
@@ -166,10 +179,7 @@ export const updateProfile = async (
         input: {
           user_id: userId,
           server_id: serverId,
-          display_name,
-          about_me,
-          avatar_url,
-          banner_url,
+          ...input,
         },
       }
     );

--- a/apollo/src/graphql/resolvers/user_profile.ts
+++ b/apollo/src/graphql/resolvers/user_profile.ts
@@ -128,23 +128,17 @@ const userProfileApollo: IResolvers = {
     },
 
     updateUserProfile: async (_, args) => {
-      const {
-        user_id,
-        server_id,
-        display_name,
-        about_me,
-        avatar_url,
-        banner_url,
+      const { user_id, server_id } = args.input;
+      const input: {
+        display_name?: string;
+        about_me?: string;
+        avatar_url?: string;
+        banner_url?: string;
       } = args.input;
 
       const userProfile = await UserProfileModel.findOneAndUpdate(
         { user_id, server_id }, // Find the user profile by user_id and server_id
-        {
-          display_name,
-          about_me,
-          avatar_url,
-          banner_url,
-        },
+        input, // Update the user profile with the input
         { new: true }
       );
 


### PR DESCRIPTION
## What?
When the user changes their user profile, the API sends all unneeded fields to GraphQL, all unneeded fields that the user does not fill in the default set to null, which data will be set to null even if they do not edit that data.

So this PR will fix that by parsing the data to get the field the user wants to edit and send only that data to the Apollo server.

## Screenshot (Required)
The client only requests to change their "about me" field.
![image](https://github.com/user-attachments/assets/f6be04eb-4244-4ff8-82c8-49ea58c48a61)

The client requests to change their "about me" and "username" fields (which are denied since the username field cannot be changed).
![image](https://github.com/user-attachments/assets/e41a6b81-9001-44af-b80e-f248f81f6024)

The client only changes their avatar.
![image](https://github.com/user-attachments/assets/5eeb2efa-2da4-450b-872b-fdf055d2a0f3)

## Additional Note
0
