### PR TITLE
BE-79: Introduce default server role & implement API endpoints for default server role

### DIFF
--- a/api/src/graphql/mutations.ts
+++ b/api/src/graphql/mutations.ts
@@ -312,6 +312,7 @@ export const serverRoleMutations = {
         position
         permissions
         is_admin
+        default
         last_modified
         number_of_users
       }
@@ -328,6 +329,27 @@ export const serverRoleMutations = {
         position
         permissions
         is_admin
+        default
+        last_modified
+        number_of_users
+      }
+    }
+  `,
+  UPDATE_DEFAULT_SERVER_ROLE: gql`
+    mutation updateDefaultServerRole(
+      $server_id: ID!
+      $input: UpdateServerRoleInput!
+    ) {
+      updateDefaultServerRole(server_id: $server_id, input: $input) {
+        id
+        server_id
+        name
+        color
+        allow_anyone_mention
+        position
+        permissions
+        is_admin
+        default
         last_modified
         number_of_users
       }
@@ -344,6 +366,7 @@ export const serverRoleMutations = {
         position
         permissions
         is_admin
+        default
         last_modified
         number_of_users
       }

--- a/api/src/graphql/queries.ts
+++ b/api/src/graphql/queries.ts
@@ -275,6 +275,7 @@ export const serverRoleQueries = {
         position
         permissions
         is_admin
+        default
         last_modified
         number_of_users
       }
@@ -292,6 +293,25 @@ export const serverRoleQueries = {
         position
         permissions
         is_admin
+        default
+        last_modified
+        number_of_users
+      }
+    }
+  `,
+
+  GET_DEFAULT_SERVER_ROLE: gql`
+    query getDefaultServerRole($server_id: ID!) {
+      getDefaultServerRole(server_id: $server_id) {
+        id
+        server_id
+        name
+        color
+        allow_anyone_mention
+        position
+        permissions
+        is_admin
+        default
         last_modified
         number_of_users
       }
@@ -322,6 +342,7 @@ export const serverRoleQueries = {
         position
         permissions
         is_admin
+        default
         last_modified
         number_of_users
       }

--- a/api/src/routes/servers/server_permission.ts
+++ b/api/src/routes/servers/server_permission.ts
@@ -20,6 +20,24 @@ serverRoleRouter.post(
 );
 
 serverRoleRouter.get(
+  '/default/permissions',
+  checkServerAdminMiddleware,
+  serverRoles.getDefaultServerRolePermissions
+);
+
+serverRoleRouter.put(
+  '/default/permissions',
+  checkServerAdminMiddleware,
+  serverRoles.updateDefaultServerRolePermissions
+);
+
+serverRoleRouter.patch(
+  '/default/permissions',
+  checkServerAdminMiddleware,
+  serverRoles.updatePartialDefaultServerRolePermissions
+);
+
+serverRoleRouter.get(
   '/:roleId',
   serverRoles.getServerRole
 );

--- a/apollo/src/graphql/resolvers/servers/assigned_user_role.ts
+++ b/apollo/src/graphql/resolvers/servers/assigned_user_role.ts
@@ -126,6 +126,12 @@ const removeUserFromRoleTransaction = async ({
       throw new UserInputError("Server role not found");
     }
 
+    // if the role is the default role, do not allow the user to be removed
+    const serverRole = await ServerRoleModel.findById(role_id);
+    if (serverRole.default) {
+      throw new UserInputError("Cannot remove user from default role");
+    }
+
     const assignedUserRole = await AssignedUserRoleModel.findOneAndDelete(
       { role_id, user_id },
       { session }
@@ -172,6 +178,7 @@ const assignedUserRoleAPI: IResolvers = {
             position: serverRole.position,
             permissions: serverRole.permissions,
             is_admin: serverRole.is_admin,
+            default: serverRole.default,
             last_modified: serverRole.last_modified,
             number_of_users: roles.length,
           };

--- a/apollo/src/graphql/typedefs/servers/server_role.ts
+++ b/apollo/src/graphql/typedefs/servers/server_role.ts
@@ -10,6 +10,7 @@ const gqlTypes = gql`
     position: Int
     permissions: String
     is_admin: Boolean
+    default: Boolean
     last_modified: String
     number_of_users: Int
   }
@@ -36,11 +37,13 @@ const gqlAPI = gql`
     syncServerRole: [ServerRole]
     getServerRole(role_id: ID!): ServerRole
     getServerRoles(server_id: ID!): [ServerRole]
+    getDefaultServerRole(server_id: ID!): ServerRole
   }
 
   type Mutation {
     createServerRole(server_id: ID!, input: CreateServerRoleInput!): ServerRole
     updateServerRole(role_id: ID!, input: UpdateServerRoleInput!): ServerRole
+    updateDefaultServerRole(server_id: ID!, input: UpdateServerRoleInput!): ServerRole
     deleteServerRole(role_id: ID!): ServerRole
   }
 `;

--- a/apollo/src/models/servers/server_role.ts
+++ b/apollo/src/models/servers/server_role.ts
@@ -9,6 +9,7 @@ interface IServerRole {
   position: number;
   permissions: string;
   is_admin: boolean;
+  default: boolean;
   last_modified: Date;
 }
 
@@ -44,6 +45,11 @@ const schema = new Schema<IServerRole>(
     is_admin: {
       type: Boolean,
       default: false,
+    },
+    default: {
+      type: Boolean,
+      default: false,
+      required: [true, 'Default attribute is required!'],
     },
     last_modified: {
       type: Date,


### PR DESCRIPTION
[JIRA Ticket](https://ntploc21.atlassian.net/browse/BE-79)

# Description

The default server role (`@everyone`) is a role that has permissions applied to all members of a server. The details of the default server role are not editable or readable.

The default server role can only be updated or read from the API, we will have an additional check on the Apollo side to ensure that the default server role’s details are not accessible.

## Additional API endpoints for the default server role

- `GET /api/v1/servers/:serverId/roles/default/permissions`: Get default server role permissions
- `PUT /api/v1/servers/:serverId/roles/default/permissions`: Update default server role permissions
- `PATCH /api/v1/servers/:serverId/roles/default/permissions`: Update **partial** default server role permissions

# Acceptance Criteria
- Introduce default attribute/field in server_roles model.
- Create a default server role whenever a new server is created. It should have the following field values.
    - name: `@everyone`
    - color: #CDCDCD
    - allow_anyone_mention: `true`
    - permissions: default permission set
    - is_admin: `false`
    - position: `Integer.max`
    - default: `true` (only the default server role has this set to true, all other server roles will be set to false)
- The default server role should be deleted if the server is deleted.
- All existing API endpoints returning server role will need to return additional default field.
- Secure existing API endpoints from modifying the default server role and introduce new API endpoints for the default server role.
