### PR TITLE
BE-81: Fix remove user from role

### DIFF
--- a/apollo/package-lock.json
+++ b/apollo/package-lock.json
@@ -36,7 +36,6 @@
         "morgan": "^1.10.0",
         "short-unique-id": "^5.2.0",
         "ts-node": "^10.9.2",
-        "tsconfig-paths": "^4.2.0",
         "validator": "^13.12.0",
         "ws": "^8.18.0",
         "xss-clean": "^0.1.4"
@@ -47,6 +46,7 @@
         "@types/node": "^20.14.8",
         "@types/ws": "^8.5.11",
         "nodemon": "^3.1.4",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.5.2"
       }
     },
@@ -2460,6 +2460,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -2704,6 +2705,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3526,6 +3528,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3711,6 +3714,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",

--- a/apollo/package.json
+++ b/apollo/package.json
@@ -60,7 +60,6 @@
     "morgan": "^1.10.0",
     "short-unique-id": "^5.2.0",
     "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0",
     "validator": "^13.12.0",
     "ws": "^8.18.0",
     "xss-clean": "^0.1.4"
@@ -71,6 +70,7 @@
     "@types/node": "^20.14.8",
     "@types/ws": "^8.5.11",
     "nodemon": "^3.1.4",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.5.2"
   }
 }

--- a/apollo/src/graphql/resolvers/servers/assigned_user_role.ts
+++ b/apollo/src/graphql/resolvers/servers/assigned_user_role.ts
@@ -133,7 +133,10 @@ const removeUserFromRoleTransaction = async ({
     }
 
     const assignedUserRole = await AssignedUserRoleModel.findOneAndDelete(
-      { role_id, user_id },
+      {
+        '_id.server_role_id': role_id,
+        '_id.user_id': user_id,
+      },
       { session }
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "concurrently": "^7.6.0",
         "jsonwebtoken": "^9.0.2"
+      },
+      "devDependencies": {
+        "tsconfig-paths": "^4.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -208,6 +211,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -298,6 +314,16 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -401,6 +427,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -423,6 +459,21 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "concurrently": "^7.6.0",
     "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "tsconfig-paths": "^4.2.0"
   }
 }


### PR DESCRIPTION
# Description
The current API endpoint for removing a member from a role has a problem, in that it could remove a user from another role, different from the role on the parameter. That is due to the way we remove it from the database.

```
const assignedUserRole = await AssignedUserRoleModel.findOneAndDelete(
      { role_id, user_id },
      { session }
);
```
The schema for `AssignedUserRoleModel` has primary key `_id` containing `server_role_id` and `user_id`, so we must pass in the `server_role_id` variable instead of `role_id` (it could mistaken that it should compare the `role_id` field to `role_id` instead of `server_role_id`).

The solution is to change the above code to
```
const assignedUserRole = await AssignedUserRoleModel.findOneAndDelete(
      {
        '_id.server_role_id': role_id,
        '_id.user_id': user_id,
      },
      { session }
);
```
This will ensure it will delete the record correctly, that the record should has `server_role_id` identical to `role_id`, and `user_id` is matched.