### PR TITLE
SE-25: Return is_pinned status for the message

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "printWidth": 80
+  "printWidth": 80,
+  "endOfLine": "auto"
 }

--- a/api/src/graphql/queries.ts
+++ b/api/src/graphql/queries.ts
@@ -641,6 +641,7 @@ export const messageQueries = {
           is_deleted
         }
 
+        is_pinned
         is_modified
         createdAt
       }
@@ -691,6 +692,7 @@ export const messageQueries = {
           is_deleted
         }
 
+        is_pinned
         is_modified
         createdAt
       }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,12 @@ export default [
   {
     plugins: { prettier: prettierPlugin },
     rules: {
-      "prettier/prettier": "error",
+      "prettier/prettier": [
+        "error",
+        {
+          endOfLine: "auto",
+        },
+      ],
       "no-console": "off",
       "no-shadow": "off",
       "prefer-const": "off",


### PR DESCRIPTION
# What?
This pull request adds an `is_pinned` status to the message model and updates the API responses to include this information. This will allow the front end to determine whether a message is pinned without having to fetch all pinned messages.

# Changes Log
- [X] Modified the GraphQL of the message query to include `is_pinned`.
- [X] Properly test every message query.
