### PR TITLE
SE-26: Handle multiple same query types for search messages.

### DIFF
--- a/api/src/controllers/servers/message.ts
+++ b/api/src/controllers/servers/message.ts
@@ -143,8 +143,8 @@ export const searchMessages = async (
   const { page, limit } = req.query;
   const {
     content,
-    author_id,
-    mentions,
+    author_id: _author_id,
+    mentions: _mentions,
     has,
     in: _inChannel,
     conversationIds,
@@ -159,6 +159,17 @@ export const searchMessages = async (
   const inConversation = Array.isArray(conversationIds)
     ? conversationIds
     : [conversationIds];
+
+  const author_id = _author_id
+    ? Array.isArray(_author_id)
+      ? _author_id
+      : [_author_id]
+    : [];
+  const mentions = _mentions
+    ? Array.isArray(_mentions)
+      ? _mentions
+      : [_mentions]
+    : [];
 
   if (inChannel.length === 0 && inConversation.length === 0) {
     // TODO: Do a global search for the server

--- a/apollo/src/graphql/resolvers/conversations/message.ts
+++ b/apollo/src/graphql/resolvers/conversations/message.ts
@@ -491,13 +491,14 @@ const searchMessages = async (
   }
 
   // 3. Filter by sender
-  if (from) {
-    messageQuery.sender_id = from;
+  if (from && from.length > 0) {
+    const senders = await UserProfileModel.find({ $in: from });
+    messageQuery.sender_id = { $in: senders.map((sender) => sender.user_id) };
   }
 
   // 4. Filter by mention
-  if (mention) {
-    const mentions = await MentionModel.find({ mention_user_id: mention });
+  if (mention && mention.length > 0) {
+    const mentions = await MentionModel.find({ $in: mention });
     messageQuery._id = { $in: mentions.map((mention) => mention.message_id) };
   }
 

--- a/apollo/src/graphql/typedefs/conversations/message.ts
+++ b/apollo/src/graphql/typedefs/conversations/message.ts
@@ -51,8 +51,8 @@ const gqlQuery = gql`
     inChannel: [ID]
     inConversation: [ID]
     text: String
-    from: ID
-    mention: ID
+    from: [ID]
+    mention: [ID]
     has: AttachmentType
   }
 


### PR DESCRIPTION
# What?
When searching for a message in a channel or a conversation, if a user wants to find a message that mentions user A or mentions user B, i.e., `mentions: A mentions: B` query, it will return an error that an array of mentions cannot apply for ID. 

Therefore, this bug ticket will fix this issue, searching the same query type multiple times is supported.

# Acceptance Criteria
- [X] Support search a query type multiple times - I.e., type mentions, from (author_id),…
- [X] Properly handles test.

