### PR TITLE
SE-36: Publish swagger documents to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,12 @@ name: Deploy Swagger Docs
 on:
   push:
     branches:
-      - playground
+      - master
+    paths-ignore:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
+      - "LICENSE"
 
 permissions:
   contents: write

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,100 @@
+name: Deploy Swagger Docs
+
+on:
+  push:
+    branches:
+      - playground
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create docs directory
+        working-directory: api
+        run: mkdir docs
+
+      - name: Copy Swagger UI files
+        working-directory: api
+        run: cp node_modules/swagger-ui-dist/* docs/ -r
+
+      - name: Generate Swagger docs
+        working-directory: api
+        run: |
+          pnpm run generate-swagger
+          cp swagger.json ./docs
+          cp dist/swagger/operations-sorter.js ./docs
+
+      - name: Create HTML
+        working-directory: api
+        run: |
+          cat << 'EOF' > docs/index.html
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="UTF-8" />
+              <title>API Documentation</title>
+              <link
+                rel="stylesheet"
+                type="text/css"
+                href="https://unpkg.com/swagger-ui-dist/swagger-ui.css"
+              />
+            </head>
+            <body>
+              <div id="swagger-ui"></div>
+              <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+              <script src="./operations-sorter.js"></script>
+              <script>
+                window.onload = function () {
+                  const ui = SwaggerUIBundle({
+                    url: "swagger.json",
+                    dom_id: "#swagger-ui",
+                    operationsSorter: (a, b) => {
+                      const methodsOrder = [
+                        "get",
+                        "post",
+                        "put",
+                        "patch",
+                        "delete",
+                        "options",
+                        "trace",
+                      ];
+                      let result =
+                        methodsOrder.indexOf(a.get("method")) -
+                        methodsOrder.indexOf(b.get("method"));
+
+                      if (result === 0) {
+                        result = a.get("path").localeCompare(b.get("path"));
+                      }
+
+                      return result;
+                    },
+                  });
+                };
+              </script>
+            </body>
+          </html>
+          EOF
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./api/docs

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
     "@": "dist"
   },
   "scripts": {
+    "generate-swagger": "tsc && node -r module-alias/register dist/swagger/generate-swagger.js",
     "lint": "eslint \"./**/*.ts\"",
     "prettier": "prettier --check \"./**/*.{ts,json}\"",
     "prettier-fix": "prettier --write \"./**/*.{ts,json}\"",
@@ -21,6 +22,7 @@
     "sharp": "^0.33.4",
     "streamifier": "^0.1.1",
     "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-dist": "^5.17.14",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^10.0.0"
   },

--- a/api/src/swagger/generate-swagger.ts
+++ b/api/src/swagger/generate-swagger.ts
@@ -1,0 +1,4 @@
+import { swaggerSpec } from ".";
+import fs from "fs";
+
+fs.writeFileSync("swagger.json", JSON.stringify(swaggerSpec, null, 2));

--- a/api/src/swagger/index.ts
+++ b/api/src/swagger/index.ts
@@ -1,7 +1,9 @@
 import swaggerJSDoc from "swagger-jsdoc";
 import swaggerUi, { SwaggerUiOptions } from "swagger-ui-express";
 import { Router } from "express";
-import config from "./config";
+
+import config from "../config";
+import operationsSorter from "./operations-sorter";
 
 const options = {
   definition: {
@@ -34,26 +36,7 @@ const swaggerSpec = swaggerJSDoc(options);
 
 const swaggerOptions: SwaggerUiOptions = {
   swaggerOptions: {
-    operationsSorter: (a: any, b: any) => {
-      const methodsOrder = [
-        "get",
-        "post",
-        "put",
-        "patch",
-        "delete",
-        "options",
-        "trace",
-      ];
-      let result =
-        methodsOrder.indexOf(a.get("method")) -
-        methodsOrder.indexOf(b.get("method"));
-
-      if (result === 0) {
-        result = a.get("path").localeCompare(b.get("path"));
-      }
-
-      return result;
-    },
+    operationsSorter,
   },
 };
 
@@ -67,4 +50,5 @@ const swaggerRouter = Router()
     res.json(swaggerSpec);
   });
 
+export { swaggerSpec };
 export default swaggerRouter;

--- a/api/src/swagger/operations-sorter.ts
+++ b/api/src/swagger/operations-sorter.ts
@@ -1,0 +1,22 @@
+const operationsSorter = (a: any, b: any) => {
+  const methodsOrder = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "options",
+    "trace",
+  ];
+  let result =
+    methodsOrder.indexOf(a.get("method")) -
+    methodsOrder.indexOf(b.get("method"));
+
+  if (result === 0) {
+    result = a.get("path").localeCompare(b.get("path"));
+  }
+
+  return result;
+};
+
+export default operationsSorter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       swagger-jsdoc:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)
+      swagger-ui-dist:
+        specifier: ^5.17.14
+        version: 5.17.14
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@4.21.1)


### PR DESCRIPTION
# Description
- Add script to generate `swagger.json`
- Add workflow to build and deploy to GitHub Pages automatically.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

