### PR TITLE
SE-66: Migrate Emojis CDN URL

### DIFF
--- a/api/src/controllers/emojis.ts
+++ b/api/src/controllers/emojis.ts
@@ -208,8 +208,6 @@ export const createServerEmoji = async (
     );
 
     const image_url = await processImage(image, `emojis`, emoji.id);
-    console.log(emoji);
-    console.log(image_url);
 
     if (!image_url) {
       await graphQLClient().request(

--- a/api/src/graphql/mutations.ts
+++ b/api/src/graphql/mutations.ts
@@ -314,6 +314,16 @@ export const serverEmojiMutations = {
       hardDeleteServerEmoji(emoji_id: $emoji_id)
     }
   `,
+  RENAME_SERVER_EMOJI_URL: gql`
+    mutation renameServerEmojiUrl($emoji_id: ID!, $image_url: String!) {
+      renameServerEmojiUrl(emoji_id: $emoji_id, image_url: $image_url) {
+        id
+        name
+        image_url
+        uploader_id
+      }
+    }
+  `,
 };
 
 // Channels (and its Permission) Mutation

--- a/api/src/utils/storage.ts
+++ b/api/src/utils/storage.ts
@@ -47,8 +47,6 @@ export const uploadToS3 = async (
     const stream = createReadStream();
     const buffer = await streamToBuffer(stream);
 
-    console.log(filename);
-
     // Generate a unique key for the file
     const extension = filename.split(".").pop();
     let key = `${folder}/${uuidv4()}${extension ? `.${extension}` : ""}`;

--- a/apollo/src/graphql/resolvers/emojis.ts
+++ b/apollo/src/graphql/resolvers/emojis.ts
@@ -535,6 +535,23 @@ const emojisAPI: IResolvers = {
         throw new Error("Please confirm the action.");
       }
     },
+
+    // This function will rename the server emoji's URL.
+    renameServerEmojiUrl: async (_, { emoji_id, image_url }) => {
+      try {
+        const emoji = await EmojiModel.findByIdAndUpdate(
+          emoji_id,
+          {
+            image_url: image_url,
+          },
+          { new: true }
+        );
+
+        return emoji;
+      } catch (error: any) {
+        throw new Error(error);
+      }
+    },
   },
 };
 

--- a/apollo/src/graphql/typedefs/emojis.ts
+++ b/apollo/src/graphql/typedefs/emojis.ts
@@ -54,6 +54,9 @@ const gqlAPI = gql`
 
     # Use to sync server emojis to the unified database
     syncServerEmojis(confirm: Boolean): Boolean
+
+    # Use to rename the server emoji's URL
+    renameServerEmojiUrl(emoji_id: ID!, image_url: String!): Emoji
   }
 `;
 


### PR DESCRIPTION
# What?

This pull request migrates the CDN URL structure for emojis from `cdn_url/emojis/server_id/emoji_id.png` to `cdn_url/emojis/emoji_id.png`. This simplification improves accessibility and performance.

# What's New?
- URL Generation Update: Modified the backend code to generate CDN URLs using the new cdn_url/emojis/emoji_id.png format.
- Migration Script: Implemented a migration script to update any stored emoji URLs in the database or other persistent storage.
- Frontend/Client Updates (If applicable): Updated any frontend or client-side code that uses emoji URLs to use the new format. (If the front end is in a separate repo, this should be noted, and a corresponding PR should be created there).

# Changes Log
- Modified backend code for CDN URL generation.
- Implemented database migration script.
- Updated relevant frontend/client code (if applicable).

